### PR TITLE
[Bug-395] Fix bug text `Forgot Password` is broken into 2 lines after login failed

### DIFF
--- a/lib/widgets/auth/auth_form.dart
+++ b/lib/widgets/auth/auth_form.dart
@@ -145,12 +145,12 @@ class _AuthFormState extends State<AuthForm> {
                         if (state is WrongCredentials)
                           Text(
                             'Incorrect email or password',
-                            style: TextStyle(color: Colors.red),
+                            style: TextStyle(color: Colors.red, fontSize: 13.0),
                           ),
                         if (state is AuthenticationError)
                           Text(
                             'Server is unavailable',
-                            style: TextStyle(color: Colors.red),
+                            style: TextStyle(color: Colors.red, fontSize: 13.0),
                           ),
                         Expanded(
                           child: Align(


### PR DESCRIPTION
Refer to this bug: [https://github.com/linagora/Twake-Mobile/issues/395](https://github.com/linagora/Twake-Mobile/issues/395)

Result: 
<img width="293" alt="Screen Shot 2021-04-09 at 10 28 47" src="https://user-images.githubusercontent.com/16035728/114124726-42e0d980-991f-11eb-9ed9-bea20031f3cf.png">
