### PR TITLE
[Bug-399] Keyboard auto-correction/ predection should be off when inputting the password

### DIFF
--- a/lib/widgets/auth/auth_form.dart
+++ b/lib/widgets/auth/auth_form.dart
@@ -286,6 +286,8 @@ class __AuthTextFormState extends State<_AuthTextForm> {
   @override
   Widget build(BuildContext context) {
     return TextFormField(
+      autocorrect: widget.obscured ? false : true,
+      enableSuggestions: widget.obscured ? false : true,
       // style: TextStyle(fontSize: Dim.tm2(decimal: 0.2)),
       obscureText: widget.obscured ? _obscured : false,
       validator: widget.validator,


### PR DESCRIPTION
Refer to this bug: [https://github.com/linagora/Twake-Mobile/issues/399](https://github.com/linagora/Twake-Mobile/issues/399)