### PR TITLE
[Bug-325] The keyboard hides the error message when creating a channel fails

### DIFF
--- a/lib/widgets/sheets/add/channel_info_form.dart
+++ b/lib/widgets/sheets/add/channel_info_form.dart
@@ -213,7 +213,10 @@ class _ChannelInfoFormState extends State<ChannelInfoForm> {
                 trailingTitle: 'Create',
                 trailingAction: createIsBlocked || !_canGoNext
                     ? null
-                    : () => context.read<AddChannelBloc>().add(Create()),
+                    : () {
+                        _closeKeyboards(context);
+                        context.read<AddChannelBloc>().add(Create());
+                      },
               ),
               SizedBox(height: 16),
               Container(


### PR DESCRIPTION
Refer to this bug: [https://github.com/linagora/Twake-Mobile/issues/325](https://github.com/linagora/Twake-Mobile/issues/325)