### PR TITLE
fix swipe bloc state

### DIFF
--- a/lib/pages/chat/messages_grouped_list.dart
+++ b/lib/pages/chat/messages_grouped_list.dart
@@ -181,8 +181,8 @@ class _MessagesGroupedListState extends State<MessagesGroupedList> {
                   Get.find<ThreadMessagesCubit>().swipeReply(
                     message.id,
                   );
-
                   setState(() {});
+                  Get.find<ThreadMessagesCubit>().reset();
                 },
                 color: Colors.transparent),
           ],


### PR DESCRIPTION
Now when we just do swipes on different messages in a row without doing any actions we emit the same state and bloc doest rebuild the swipe response, so we need to emit an intermediate state
