### PR TITLE
Fix #1006: The second reaction cannot display when the message is short

### DIFF
--- a/lib/pages/chat/message_tile.dart
+++ b/lib/pages/chat/message_tile.dart
@@ -139,6 +139,7 @@ class _MessageTileState<T extends BaseMessagesCubit>
             Flexible(
               child: Container(
                 child: Stack(
+                  alignment: Alignment.bottomLeft,
                   children: [
                     Container(
                       padding: _message.reactions.isEmpty
@@ -347,9 +348,8 @@ class _MessageTileState<T extends BaseMessagesCubit>
                       ),
                     ),
                     if (!widget.hideReaction)
-                      Positioned(
-                        left: 17.0,
-                        bottom: -1.0,
+                      Transform(
+                        transform: Matrix4.translationValues(17, -1, 0.0),
                         child: Wrap(
                           runSpacing: Dim.heightMultiplier,
                           crossAxisAlignment: WrapCrossAlignment.center,


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/29337364/142155547-8d17023f-9ad5-46ed-ab48-c1a0308a6d18.png" width="300"/>


