### PR TITLE
Fix #1086: The copy magic link message is hidden by the notch on iOS

### DIFF
--- a/lib/pages/magic_link/invitation_people_page.dart
+++ b/lib/pages/magic_link/invitation_people_page.dart
@@ -322,7 +322,7 @@ class _InvitationPeoplePageState extends State<InvitationPeoplePage> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           backgroundColor: Colors.white,
-          margin: EdgeInsets.fromLTRB(10.0, 20.0, 10.0, Dim.maxScreenHeight! - 110),
+          margin: EdgeInsets.fromLTRB(10.0, 20.0, 10.0, Dim.maxScreenHeight! - Dim.heightPercent(16)),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(16),
           ),


### PR DESCRIPTION
iOS:
![Screen Shot 2021-11-19 at 4 14 30 PM](https://user-images.githubusercontent.com/29337364/142597565-e955b394-f766-450f-a92d-6ba61868d50b.png)

Android:
![Screen Shot 2021-11-19 at 4 17 25 PM](https://user-images.githubusercontent.com/29337364/142597584-3cd07056-cb14-4488-8211-117794ff4d3d.png)


