### PR TITLE
fix #914 sending time is incorrect with different times on devices

### DIFF
--- a/lib/pages/chat/messages_grouped_list.dart
+++ b/lib/pages/chat/messages_grouped_list.dart
@@ -83,7 +83,11 @@ class _MessagesGroupedListState extends State<MessagesGroupedList> {
       groupComparator: (DateTime value1, DateTime value2) =>
           value1.compareTo(value2),
       itemComparator: (Message m1, Message m2) {
-        return m1.createdAt.compareTo(m2.createdAt);
+        if (m1.createdAt.compareTo(m2.createdAt) == -1) {
+          return m1.createdAt.compareTo(m2.createdAt);
+        } else {
+          return m2.createdAt.compareTo(m1.createdAt);
+        }
       },
       separator: SizedBox(height: 1.0),
       groupSeparatorBuilder: (DateTime dt) {


### PR DESCRIPTION
Until we get the time from the server, there may be an incorrect order in the messages due to different times on the device


How it was
https://user-images.githubusercontent.com/51719953/144254499-c5c290f6-c18c-46e5-b1ff-136af9184706.mp4

how it is now 
https://user-images.githubusercontent.com/51719953/144254579-cc764895-575d-41ff-a548-a1cc2283547d.mp4



