### PR TITLE
bug fix file rerender

### DIFF
--- a/lib/blocs/cache_file_cubit/cache_file_cubit.dart
+++ b/lib/blocs/cache_file_cubit/cache_file_cubit.dart
@@ -1,0 +1,30 @@
+import 'package:bloc/bloc.dart';
+import 'package:collection/collection.dart';
+import 'package:equatable/equatable.dart';
+import 'package:twake/models/file/file.dart';
+
+part 'cache_file_state.dart';
+
+class CacheFileCubit extends Cubit<CacheFileState> {
+  CacheFileCubit() : super(CacheFilesInitial(fileList: []));
+  List<File> fileList = [];
+
+  void setFile({required File file}) async {
+    fileList.firstWhereOrNull((cacheFile) => cacheFile.id == file.id) == null
+        ? fileList.add(file)
+        : null;
+  }
+
+  void findCacheFile({required String fileId}) async {
+    final cacheFile = fileList.firstWhereOrNull((file) => file.id == fileId);
+    cacheFile == null
+        ? emit(CacheFileNotFoun())
+        : emit(CacheFileFound(cacheFile: cacheFile));
+  }
+
+  void cleanCacheFiles({required File file}) async {
+    fileList = [];
+
+    emit(CacheFilesInitial(fileList: fileList));
+  }
+}

--- a/lib/blocs/cache_file_cubit/cache_file_cubit.dart
+++ b/lib/blocs/cache_file_cubit/cache_file_cubit.dart
@@ -6,25 +6,22 @@ import 'package:twake/models/file/file.dart';
 part 'cache_file_state.dart';
 
 class CacheFileCubit extends Cubit<CacheFileState> {
-  CacheFileCubit() : super(CacheFilesInitial(fileList: []));
-  List<File> fileList = [];
+  CacheFileCubit() : super(CacheFileState(fileList: []));
 
-  void setFile({required File file}) async {
-    fileList.firstWhereOrNull((cacheFile) => cacheFile.id == file.id) == null
-        ? fileList.add(file)
-        : null;
+  void cacheFile({required File file}) async {
+    List<File> cachedList = [...state.fileList];
+    final cachedFile = state.fileList.firstWhereOrNull((cacheFile) => cacheFile.id == file.id);
+    if(cachedFile == null) {
+      cachedList.add(file);
+    }
+    emit(CacheFileState(fileList: cachedList));
   }
 
-  void findCacheFile({required String fileId}) async {
-    final cacheFile = fileList.firstWhereOrNull((file) => file.id == fileId);
-    cacheFile == null
-        ? emit(CacheFileNotFoun())
-        : emit(CacheFileFound(cacheFile: cacheFile));
+  File? findCachedFile({required String fileId}) {
+    return state.fileList.firstWhereOrNull((file) => file.id == fileId);
   }
 
-  void cleanCacheFiles({required File file}) async {
-    fileList = [];
-
-    emit(CacheFilesInitial(fileList: fileList));
+  void cleanCachedFiles() async {
+    emit(CacheFileState(fileList: []));
   }
 }

--- a/lib/blocs/cache_file_cubit/cache_file_state.dart
+++ b/lib/blocs/cache_file_cubit/cache_file_state.dart
@@ -1,0 +1,32 @@
+part of 'cache_file_cubit.dart';
+
+abstract class CacheFileState extends Equatable {
+  const CacheFileState();
+
+  @override
+  List<Object> get props => [];
+}
+
+class CacheFilesInitial extends CacheFileState {
+  final List<File> fileList;
+
+  const CacheFilesInitial({required this.fileList});
+
+  @override
+  List<Object> get props => [fileList];
+}
+
+class CacheFileNotFoun extends CacheFileState {
+  const CacheFileNotFoun();
+  @override
+  List<Object> get props => [];
+}
+
+class CacheFileFound extends CacheFileState {
+  final File cacheFile;
+
+  const CacheFileFound({required this.cacheFile});
+
+  @override
+  List<Object> get props => [cacheFile];
+}

--- a/lib/blocs/cache_file_cubit/cache_file_state.dart
+++ b/lib/blocs/cache_file_cubit/cache_file_state.dart
@@ -1,32 +1,14 @@
 part of 'cache_file_cubit.dart';
 
-abstract class CacheFileState extends Equatable {
-  const CacheFileState();
-
-  @override
-  List<Object> get props => [];
-}
-
-class CacheFilesInitial extends CacheFileState {
+class CacheFileState extends Equatable {
   final List<File> fileList;
 
-  const CacheFilesInitial({required this.fileList});
+  const CacheFileState({required this.fileList});
+
+  CacheFileState copyWith({List<File>? newList}) {
+    return CacheFileState(fileList: newList ?? this.fileList);
+  }
 
   @override
   List<Object> get props => [fileList];
-}
-
-class CacheFileNotFoun extends CacheFileState {
-  const CacheFileNotFoun();
-  @override
-  List<Object> get props => [];
-}
-
-class CacheFileFound extends CacheFileState {
-  final File cacheFile;
-
-  const CacheFileFound({required this.cacheFile});
-
-  @override
-  List<Object> get props => [cacheFile];
 }

--- a/lib/di/home_binding.dart
+++ b/lib/di/home_binding.dart
@@ -2,6 +2,7 @@ import 'package:get/get.dart';
 import 'package:twake/blocs/account_cubit/account_cubit.dart';
 import 'package:twake/blocs/authentication_cubit/authentication_cubit.dart';
 import 'package:twake/blocs/badges_cubit/badges_cubit.dart';
+import 'package:twake/blocs/cache_file_cubit/cache_file_cubit.dart';
 import 'package:twake/blocs/channels_cubit/channels_cubit.dart';
 import 'package:twake/blocs/companies_cubit/companies_cubit.dart';
 import 'package:twake/blocs/file_cubit/file_cubit.dart';
@@ -58,6 +59,9 @@ class HomeBinding implements Bindings {
 
     final invitationCubit = InvitationCubit();
     Get.put(invitationCubit, permanent: true);
+
+     final cacheFileCubit = CacheFileCubit();
+    Get.put(cacheFileCubit, permanent: true);
 
     Future.delayed(Duration(seconds: 5), () {
       if (Globals.instance.token != null) authenticationCubit.registerDevice();

--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:get/get.dart';
+import 'package:twake/blocs/cache_file_cubit/cache_file_cubit.dart';
 import 'package:twake/blocs/channels_cubit/channels_cubit.dart';
 import 'package:twake/blocs/companies_cubit/companies_cubit.dart';
 import 'package:twake/blocs/file_cubit/file_cubit.dart';
@@ -38,6 +39,7 @@ class Chat<T extends BaseChannelsCubit> extends StatelessWidget {
           onTap: () {
             popBack();
             Get.find<ThreadMessagesCubit>().reset();
+            Get.find<CacheFileCubit>().cleanCachedFiles();
           },
           child: Padding(
             padding: const EdgeInsets.symmetric(horizontal: 20.0),

--- a/lib/widgets/common/file_tile.dart
+++ b/lib/widgets/common/file_tile.dart
@@ -3,6 +3,7 @@ import 'package:filesize/filesize.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:open_file/open_file.dart';
+import 'package:twake/blocs/cache_file_cubit/cache_file_cubit.dart';
 import 'package:twake/blocs/file_cubit/file_cubit.dart';
 import 'package:twake/config/image_path.dart';
 import 'package:twake/utils/extensions.dart';
@@ -15,59 +16,73 @@ class FileTile extends StatelessWidget {
   final String fileId;
   final bool isMyMessage;
 
+<<<<<<< HEAD
   FileTile({required this.fileId, required this.isMyMessage}) : super(key: ValueKey(fileId));
+=======
+  FileTile({required this.fileId, required this.isMyMessage})
+      : super(key: ValueKey(fileId));
+>>>>>>> c803baa1 (fix #1135 sender chat text color inside file)
 
   @override
   Widget build(BuildContext context) {
-      return FutureBuilder(
-        future: Get.find<FileCubit>().getFileData(id: fileId),
-        builder: (context, snapshot) {
-          if (snapshot.connectionState == ConnectionState.done) {
-            if (snapshot.data == null) {
+    Get.find<CacheFileCubit>().findCacheFile(fileId: fileId);
+    File? cacheFile;
+    final cacheFileState = Get.find<CacheFileCubit>().state;
+    (cacheFileState is CacheFileFound)
+        ? cacheFile = cacheFileState.cacheFile
+        : cacheFile = null;
+
+    return cacheFile == null
+        ? FutureBuilder(
+            future: Get.find<FileCubit>().getFileData(id: fileId),
+            builder: (context, snapshot) {
+              if (snapshot.connectionState == ConnectionState.done) {
+                if (snapshot.data == null) {
+                  return _buildLoadingLayout();
+                }
+                final file = (snapshot.data as File);
+                Get.find<CacheFileCubit>().setFile(file: file);
+                return _buildFileWidget(file);
+              }
               return _buildLoadingLayout();
-            }
-            final file = (snapshot.data as File);
-            return _buildFileWidget(file);
-          }
-          return _buildLoadingLayout();
-        },
-      );
+            },
+          )
+        : _buildFileWidget(cacheFile);
   }
 
   _buildLoadingLayout() => ClipRRect(
-      borderRadius: BorderRadius.all(Radius.circular(8)),
-      child: ShimmerLoading(
-        width: double.maxFinite,
-        height: _fileTileHeight,
-        isLoading: true,
-        child: Container(),
-      ),
-  );
+        borderRadius: BorderRadius.all(Radius.circular(8)),
+        child: ShimmerLoading(
+          width: double.maxFinite,
+          height: _fileTileHeight,
+          isLoading: true,
+          child: Container(),
+        ),
+      );
 
-  _buildFileWidget(File file) => Row(
-        children: [
-          _buildThumbnail(file),
-          SizedBox(width: 12.0),
-          Flexible(
-            child: _buildInfo(file),
-          ),
-        ]
-  );
+  _buildFileWidget(File file) => Row(children: [
+        _buildThumbnail(file),
+        SizedBox(width: 12.0),
+        Flexible(
+          child: _buildInfo(file),
+        ),
+      ]);
 
   _buildThumbnail(File file) => SizedBox(
-      width: _fileTileHeight,
-      height: _fileTileHeight,
-      child: Stack(
-        alignment: Alignment.center,
-        children: [
-          _buildFilePreview(file),
-        ],
-      ),
-  );
+        width: _fileTileHeight,
+        height: _fileTileHeight,
+        child: Stack(
+          alignment: Alignment.center,
+          children: [
+            _buildFilePreview(file),
+          ],
+        ),
+      );
 
   _buildFilePreview(File file) => GestureDetector(
       onTap: () async {
-        final imageCachedPath = await Utilities.getCachedImagePath(file.thumbnailUrl);
+        final imageCachedPath =
+            await Utilities.getCachedImagePath(file.thumbnailUrl);
         await OpenFile.open(imageCachedPath, type: file.metadata.mime);
       },
       child: file.metadata.mime.isImageMimeType
@@ -86,6 +101,7 @@ class FileTile extends StatelessWidget {
                       child: Container());
                 },
               ),
+<<<<<<< HEAD
           )
           : Image.asset(imageFile, width: 32, height: 32, color: isMyMessage ? null : Colors.grey)
   );
@@ -112,4 +128,34 @@ class FileTile extends StatelessWidget {
         ),
       ],
   );
+=======
+            )
+          : Image.asset(imageFile,
+              width: 32, height: 32, color: isMyMessage ? null : Colors.grey));
+
+  _buildInfo(File file) => Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          RichText(
+              text: TextSpan(
+                  text: file.metadata.name,
+                  style: TextStyle(
+                      fontSize: 16.0,
+                      color: isMyMessage ? Colors.white : Colors.black)),
+              overflow: TextOverflow.ellipsis,
+              maxLines: 2),
+          Text(
+            filesize(file.uploadData.size),
+            textAlign: TextAlign.start,
+            style: TextStyle(
+                fontSize: 11.0,
+                fontWeight: FontWeight.w400,
+                fontStyle: FontStyle.italic,
+                color: isMyMessage
+                    ? Color.fromRGBO(255, 255, 255, 0.58)
+                    : Color.fromRGBO(0, 0, 0, 0.58)),
+          ),
+        ],
+      );
+>>>>>>> c803baa1 (fix #1135 sender chat text color inside file)
 }

--- a/lib/widgets/common/file_tile.dart
+++ b/lib/widgets/common/file_tile.dart
@@ -16,22 +16,12 @@ class FileTile extends StatelessWidget {
   final String fileId;
   final bool isMyMessage;
 
-<<<<<<< HEAD
-  FileTile({required this.fileId, required this.isMyMessage}) : super(key: ValueKey(fileId));
-=======
   FileTile({required this.fileId, required this.isMyMessage})
       : super(key: ValueKey(fileId));
->>>>>>> c803baa1 (fix #1135 sender chat text color inside file)
 
   @override
   Widget build(BuildContext context) {
-    Get.find<CacheFileCubit>().findCacheFile(fileId: fileId);
-    File? cacheFile;
-    final cacheFileState = Get.find<CacheFileCubit>().state;
-    (cacheFileState is CacheFileFound)
-        ? cacheFile = cacheFileState.cacheFile
-        : cacheFile = null;
-
+    File? cacheFile = Get.find<CacheFileCubit>().findCachedFile(fileId: fileId);
     return cacheFile == null
         ? FutureBuilder(
             future: Get.find<FileCubit>().getFileData(id: fileId),
@@ -41,7 +31,7 @@ class FileTile extends StatelessWidget {
                   return _buildLoadingLayout();
                 }
                 final file = (snapshot.data as File);
-                Get.find<CacheFileCubit>().setFile(file: file);
+                Get.find<CacheFileCubit>().cacheFile(file: file);
                 return _buildFileWidget(file);
               }
               return _buildLoadingLayout();
@@ -80,58 +70,31 @@ class FileTile extends StatelessWidget {
       );
 
   _buildFilePreview(File file) => GestureDetector(
-      onTap: () async {
-        final imageCachedPath =
-            await Utilities.getCachedImagePath(file.thumbnailUrl);
-        await OpenFile.open(imageCachedPath, type: file.metadata.mime);
-      },
-      child: file.metadata.mime.isImageMimeType
-          ? ClipRRect(
-              borderRadius: BorderRadius.all(Radius.circular(8)),
-              child: CachedNetworkImage(
-                width: double.maxFinite,
-                height: double.maxFinite,
-                fit: BoxFit.cover,
-                imageUrl: file.thumbnailUrl,
-                progressIndicatorBuilder: (context, url, progress) {
-                  return ShimmerLoading(
-                      isLoading: true,
-                      width: double.maxFinite,
-                      height: double.maxFinite,
-                      child: Container());
-                },
-              ),
-<<<<<<< HEAD
-          )
-          : Image.asset(imageFile, width: 32, height: 32, color: isMyMessage ? null : Colors.grey)
-  );
-
-  _buildInfo(File file) => Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        RichText(
-            text: TextSpan(text: file.metadata.name,
-                style: TextStyle(fontSize: 16.0, color: isMyMessage ? Colors.white : Colors.black)),
-            overflow: TextOverflow.ellipsis,
-            maxLines: 2
-        ),
-        Text(
-          filesize(file.uploadData.size),
-          textAlign: TextAlign.start,
-          style: TextStyle(
-              fontSize: 11.0,
-              fontWeight: FontWeight.w400,
-              fontStyle: FontStyle.italic,
-              color: isMyMessage
-                  ? Color.fromRGBO(255, 255, 255, 0.58)
-                  : Color.fromRGBO(0, 0, 0, 0.58)),
-        ),
-      ],
-  );
-=======
-            )
-          : Image.asset(imageFile,
-              width: 32, height: 32, color: isMyMessage ? null : Colors.grey));
+        onTap: () async {
+          final imageCachedPath =
+              await Utilities.getCachedImagePath(file.thumbnailUrl);
+          await OpenFile.open(imageCachedPath, type: file.metadata.mime);
+        },
+        child: file.metadata.mime.isImageMimeType
+            ? ClipRRect(
+                borderRadius: BorderRadius.all(Radius.circular(8)),
+                child: CachedNetworkImage(
+                  width: double.maxFinite,
+                  height: double.maxFinite,
+                  fit: BoxFit.cover,
+                  imageUrl: file.thumbnailUrl,
+                  progressIndicatorBuilder: (context, url, progress) {
+                    return ShimmerLoading(
+                        isLoading: true,
+                        width: double.maxFinite,
+                        height: double.maxFinite,
+                        child: Container());
+                  },
+                ),
+              )
+            : Image.asset(imageFile,
+                width: 32, height: 32, color: isMyMessage ? null : Colors.grey),
+      );
 
   _buildInfo(File file) => Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -157,5 +120,4 @@ class FileTile extends StatelessWidget {
           ),
         ],
       );
->>>>>>> c803baa1 (fix #1135 sender chat text color inside file)
 }


### PR DESCRIPTION
Bug fix file rerender
If I get fileList from state in cubits methods like that `List<File> fileList = [...state.fileList];` in this case when we scroll and fetch new messages the files start rerending again, I don't know, that why I left it like that, @huynguyennovem you can change it if you want, this will be good  