### PR TITLE
Fix 1247: The space between 2 chat bubbles wider than the design

### DIFF
--- a/lib/pages/chat/message_tile.dart
+++ b/lib/pages/chat/message_tile.dart
@@ -130,7 +130,7 @@ class _MessageTileState<T extends BaseMessagesCubit>
           }
         },
         child: Container(
-          margin: EdgeInsets.symmetric(vertical: !_isMyMessage ? 6 : 1),
+          margin: EdgeInsets.symmetric(vertical: 1),
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.end,
             mainAxisSize: MainAxisSize.max,


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/29337364/154013189-cfb0afc6-c7de-4770-9876-fe0f4576cb32.png" width="360"/>

<img src="https://user-images.githubusercontent.com/29337364/154013203-7c1d6c3e-5d77-427b-a6ce-7ad3d07b9389.png" width="360"/>