### PR TITLE
Fix 1325: Can not back to Home after shared file (only after re-login app)

### DIFF
--- a/lib/pages/account/account_settings.dart
+++ b/lib/pages/account/account_settings.dart
@@ -75,7 +75,9 @@ class _AccountSettingsState extends State<AccountSettings> {
       listenWhen: (_, current) => current is LogoutInProgress,
       listener: (context, authenticationState) {
         if (authenticationState is LogoutInProgress) {
-          if (mounted) NavigatorService.instance.back(shouldLogout: true);
+          if (mounted) {
+            Navigator.popUntil(context, ModalRoute.withName(RoutePaths.initial));
+          }
         }
       },
       child: Scaffold(


### PR DESCRIPTION
- The cause: the implementation `NavigatorService.instance.back(shouldLogout: true)` has removed all routes, include `/initial/` route due to we can not back to Home screen.

- This is the log when logout:
```
[GETX] GOING TO ROUTE /initial//account_settings
[GETX] GOING TO ROUTE /InitialPage
[GETX] REMOVING ROUTE null
[GETX] REMOVING ROUTE /initial//account_settings
[GETX] REMOVING ROUTE /initial/
```

- Fixed demo:

https://user-images.githubusercontent.com/29337364/161012454-81e48482-b82a-4fef-9d30-8d2feeb63673.mp4


