### PR TITLE
2098: Magic link invitation by email updates

### DIFF
--- a/lib/blocs/magic_link_cubit/invitation_email_cubit/invitation_email_cubit.dart
+++ b/lib/blocs/magic_link_cubit/invitation_email_cubit/invitation_email_cubit.dart
@@ -9,7 +9,9 @@ import 'package:twake/models/invitation/email_invitation_response.dart';
 import 'package:twake/models/invitation/email_invitation_response_status.dart';
 import 'package:twake/models/workspace/workspace_role.dart';
 import 'package:twake/repositories/workspaces_repository.dart';
+import 'package:twake/utils/twake_error_messages.dart';
 import 'invitation_email_state.dart';
+import 'package:twake/utils/extensions.dart';
 
 const emailListDisplayLimit = 3;
 
@@ -26,8 +28,12 @@ class InvitationEmailCubit extends Cubit<InvitationEmailState> {
 
   void addEmail(String email) {
     List<EmailState> listEmailState = [...state.listEmailState];
-    final newEmailList = listEmailState..add(EmailState(email, EmailStatus.init));
-    emit(state.copyWith(newStatus: InvitationEmailStatus.addEmailSuccess, newEmailStates: newEmailList));
+    final newEmailList = listEmailState
+      ..add(EmailState(email, EmailStatus.init, TwakeErrorMessage.None));
+    emit(state.copyWith(
+      newStatus: InvitationEmailStatus.addEmailSuccess,
+      newEmailStates: newEmailList,
+    ));
   }
 
   void sendEmails(List<String> listEmail) async {
@@ -35,66 +41,80 @@ class InvitationEmailCubit extends Cubit<InvitationEmailState> {
 
     await _updateEmail(listEmail);
 
-    final isAllEmailValid = await _validateEmailFormat();
-
-    if(isAllEmailValid) {
-      final listEmails = state.listEmailState.where((e) =>
-          e.status == EmailStatus.valid).map((e) =>
-          e.email).toList();
-
-      if (listEmails.isNotEmpty) {
-        final invitationList = listEmails
-            .map((e) => EmailInvitation(email: e, companyRole: CompanyRole.member, workspaceRole: WorkspaceRole.member))
-            .toList();
-
-        // Sent email with API
-        List<EmailInvitationResponse> resultList = [];
-        try {
-          resultList = await _workspacesRepository.inviteUser(Globals.instance.companyId!, Globals.instance.workspaceId!, invitationList);
-        } catch (e) {
-          Logger().e('ERROR during invite user via email:\n$e');
-        }
-        if(resultList.isEmpty) {
-          emit(state.copyWith(newStatus: InvitationEmailStatus.sendEmailFail));
-          return;
-        }
-
-        // Update status of sending email to UI
-        final updatedEmailStates = resultList
-            .map((e) {
-              return e.status == EmailInvitationResponseStatus.ok
-                ? EmailState(e.email, EmailStatus.valid)
-                : EmailState(e.email, EmailStatus.invalid);
-            })
-            .toList();
-        emit(state.copyWith(newEmailStates: updatedEmailStates));
-
-        // Checking all sending email successfully or not to display result screen
-        final sentSuccessEmails = resultList
-            .where((result) => result.status == EmailInvitationResponseStatus.ok)
-            .map((e) => EmailState(e.email, EmailStatus.valid))
-            .toList();
-        if(sentSuccessEmails.isEmpty) {
-          emit(state.copyWith(newStatus: InvitationEmailStatus.sendEmailFail));
-          return;
-        }
-        emit(state.copyWith(newCachedSentSuccessEmails: sentSuccessEmails));
-
-        if(sentSuccessEmails.length > emailListDisplayLimit) {
-          final getInRangeEmailStates = sentSuccessEmails.getRange(0, emailListDisplayLimit).toList();
-          emit(state.copyWith(
-              newStatus: InvitationEmailStatus.sendEmailSuccess,
-              newEmailStates: getInRangeEmailStates));
-        } else {
-          emit(state.copyWith(
-              newStatus: InvitationEmailStatus.sendEmailSuccess,
-              newEmailStates: sentSuccessEmails));
-        }
-      } else {
-        emit(state.copyWith(newStatus: InvitationEmailStatus.sendEmailFail));
-      }
-    } else {
+    // Validate email regex pattern
+    final isAllEmailValidFormat = await _validateEmailFormat();
+    if(!isAllEmailValidFormat) {
       emit(state.copyWith(newStatus: InvitationEmailStatus.sendEmailFail));
+      return;
+    }
+
+    // Sent emails with API
+    final listValidEmails = state.listEmailState
+        .where((e) {
+          // In case that there are both succeed and failed emails
+          // and user is going to fix failed emails then re-send them,
+          // we should not re-send succeed emails that sent before.
+          final sentSucceedEmails = state.cachedSentSuccessEmails.map((e) => e.email).toList();
+          return e.status == EmailStatus.inProcessing && !sentSucceedEmails.contains(e.email);
+        })
+        .map((e) => e.email)
+        .toList();
+    final invitationList = listValidEmails
+      .map((e) => EmailInvitation(
+          email: e, companyRole: CompanyRole.member, workspaceRole: WorkspaceRole.member))
+      .toList();
+    List<EmailInvitationResponse> resultList = [];
+    try {
+      resultList = await _workspacesRepository.inviteUser(
+        Globals.instance.companyId!,
+        Globals.instance.workspaceId!,
+        invitationList,
+      );
+    } catch (e) {
+      Logger().e('ERROR during invite user via email:\n$e');
+    }
+    // Checking state.cachedSentSuccessEmails.isEmpty to make sure we can continue next steps
+    // if there was some succeed emails before.
+    if(resultList.isEmpty && state.cachedSentSuccessEmails.isEmpty) {
+      emit(state.copyWith(newStatus: InvitationEmailStatus.sendEmailFail));
+      return;
+    }
+
+    // Update status of sending email to UI
+    final resultListStates = resultList.map((e) {
+      return e.status == EmailInvitationResponseStatus.ok
+          ? EmailState(e.email, EmailStatus.valid, TwakeErrorMessage.None)
+          : EmailState(e.email, EmailStatus.invalid, e.message?.twakeErrorByStringMessage);
+    }).toList();
+    final updatedEmailStates = [...resultListStates, ...state.cachedSentSuccessEmails]
+        .toSet()
+        .toList();
+    emit(state.copyWith(newEmailStates: updatedEmailStates));
+
+    // Checking all sending email successfully or not to display result screen
+    final sentSuccessEmails = updatedEmailStates
+        .where((result) => result.status == EmailStatus.valid)
+        .toList();
+    emit(state.copyWith(newCachedSentSuccessEmails: sentSuccessEmails));
+
+    final existFailedEmail =
+        updatedEmailStates.any((emailState) => emailState.status == EmailStatus.invalid);
+    if(existFailedEmail) {
+      // Only allow go to success screen if there is no failed email,
+      // in order to user can see detail of error message
+      emit(state.copyWith(newStatus: InvitationEmailStatus.sendEmailFail));
+      return;
+    }
+
+    if(sentSuccessEmails.length > emailListDisplayLimit) {
+      final getInRangeEmailStates = sentSuccessEmails.getRange(0, emailListDisplayLimit).toList();
+      emit(state.copyWith(
+          newStatus: InvitationEmailStatus.sendEmailSuccess,
+          newEmailStates: getInRangeEmailStates));
+    } else {
+      emit(state.copyWith(
+          newStatus: InvitationEmailStatus.sendEmailSuccess,
+          newEmailStates: sentSuccessEmails));
     }
   }
 
@@ -109,8 +129,10 @@ class InvitationEmailCubit extends Cubit<InvitationEmailState> {
 
   Future<void> _updateEmail(List<String> listEmail) async {
     emit(state.copyWith(
-      newStatus: InvitationEmailStatus.updateEmailSuccess,
-      newEmailStates: listEmail.map((e) => EmailState(e, EmailStatus.init)).toList()));
+        newStatus: InvitationEmailStatus.updateEmailSuccess,
+        newEmailStates: listEmail
+            .map((e) => EmailState(e, EmailStatus.init, TwakeErrorMessage.None))
+            .toList()));
   }
 
   Future<bool> _validateEmailFormat() async {
@@ -120,13 +142,19 @@ class InvitationEmailCubit extends Cubit<InvitationEmailState> {
         return e.copyWith(newStatus: EmailStatus.init);
       }
       if(e.isValid)
-        return e.copyWith(newStatus: EmailStatus.valid);
+        return e.copyWith(newStatus: EmailStatus.inProcessing);
       else {
         countErrorEmail++;
-        return e.copyWith(newStatus: EmailStatus.invalid);
+        return e.copyWith(
+          newStatus: EmailStatus.invalid,
+          newErrorMessage: TwakeErrorMessage.EmailIsNotValidFormat,
+        );
       }
     }).toList();
-    emit(state.copyWith(newStatus: InvitationEmailStatus.verifyEmailSuccess, newEmailStates: emailUpdatedState));
+    emit(state.copyWith(
+      newStatus: InvitationEmailStatus.verifyEmailSuccess,
+      newEmailStates: emailUpdatedState,
+    ));
     return countErrorEmail == 0;
   }
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -368,5 +368,6 @@
     "emailIsNotValid": "Email format is not valid",
     "userAlreadyInWorkspace": "User is already in workspace",
     "unableInviteUser": "Unable to invite this user to your company",
-    "somethingWasWrong": "Something was wrong"
+    "somethingWasWrong": "Something was wrong",
+    "pendingUserExist": "Pending user already exists"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -364,5 +364,9 @@
                 "example": "5"
             }
         }
-    }                     
+    },
+    "emailIsNotValid": "Email format is not valid",
+    "userAlreadyInWorkspace": "User is already in workspace",
+    "unableInviteUser": "Unable to invite this user to your company",
+    "somethingWasWrong": "Something was wrong"
 }

--- a/lib/models/company/company.dart
+++ b/lib/models/company/company.dart
@@ -35,6 +35,8 @@ class Company extends BaseModel {
 
   bool get canReGenerateMagicLink => role == CompanyRole.owner || role == CompanyRole.admin;
 
+  bool get canShareMagicLinkByEmail => role == CompanyRole.owner || role == CompanyRole.admin;
+
   bool get canShareMagicLink => role != CompanyRole.guest;
 
   factory Company.fromJson({

--- a/lib/models/deeplink/email_state.dart
+++ b/lib/models/deeplink/email_state.dart
@@ -1,23 +1,30 @@
 import 'package:equatable/equatable.dart';
 import 'package:twake/models/deeplink/email_status.dart';
+import 'package:twake/utils/twake_error_messages.dart';
 
 class EmailState extends Equatable {
   final String email;
   final EmailStatus status;
+  final TwakeErrorMessage? errorMessage;
 
-  const EmailState(this.email, this.status);
+  const EmailState(this.email, this.status, this.errorMessage);
 
-  const EmailState.init() : this('', EmailStatus.init);
+  const EmailState.init() : this('', EmailStatus.init, TwakeErrorMessage.None);
 
-  EmailState copyWith({String? newEmail, EmailStatus? newStatus}) {
+  EmailState copyWith({
+    String? newEmail,
+    EmailStatus? newStatus,
+    TwakeErrorMessage? newErrorMessage,
+  }) {
     return EmailState(
         newEmail ?? this.email,
-        newStatus ?? this.status
+        newStatus ?? this.status,
+        newErrorMessage ?? this.errorMessage,
     );
   }
 
   @override
-  List<Object> get props => [email, status];
+  List<Object?> get props => [email, status, errorMessage];
 
 }
 

--- a/lib/models/deeplink/email_status.dart
+++ b/lib/models/deeplink/email_status.dart
@@ -1,3 +1,3 @@
 enum EmailStatus {
-  init, invalid, valid
+  init, inProcessing, invalid, valid
 }

--- a/lib/pages/magic_link/invitation_people_by_email_page.dart
+++ b/lib/pages/magic_link/invitation_people_by_email_page.dart
@@ -79,8 +79,7 @@ class _InvitationPeopleEmailPageState extends State<InvitationPeopleEmailPage> {
     return Container(
       color: Theme.of(context).colorScheme.secondaryContainer,
       padding: const EdgeInsets.symmetric(vertical: 14, horizontal: 20),
-      child: Stack(
-        alignment: Alignment.center,
+      child: Row(
         children: [
           !_isSentEmailSuccessfully(state)
               ? Align(
@@ -97,15 +96,19 @@ class _InvitationPeopleEmailPageState extends State<InvitationPeopleEmailPage> {
                   ),
                 )
               : SizedBox.shrink(),
-          Align(
-              alignment: Alignment.center,
-              child: Container(
-                child: Text(AppLocalizations.of(context)?.inviteUsers ?? '',
-                    style: Theme.of(context)
-                        .textTheme
-                        .headline1!
-                        .copyWith(fontWeight: FontWeight.bold, fontSize: 17)),
-              )),
+          Expanded(
+            child: Align(
+                alignment: Alignment.center,
+                child: Container(
+                  child: Text(AppLocalizations.of(context)?.inviteUsers ?? '',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context)
+                          .textTheme
+                          .headline1!
+                          .copyWith(fontWeight: FontWeight.bold, fontSize: 17)),
+                )),
+          ),
           !_isSentEmailSuccessfully(state)
               ? BlocBuilder(
                   bloc: Get.find<CompaniesCubit>(),

--- a/lib/pages/magic_link/invitation_people_page.dart
+++ b/lib/pages/magic_link/invitation_people_page.dart
@@ -230,6 +230,22 @@ class _InvitationPeoplePageState extends State<InvitationPeoplePage> {
                           .bodyText1!
                           .copyWith(fontSize: 17, fontWeight: FontWeight.w600))
                   .build(),
+              _buildButtonInviteByEmail(),
+            ],
+          ),
+        );
+      });
+
+  Widget _buildButtonInviteByEmail() {
+    return BlocBuilder<CompaniesCubit, CompaniesState>(
+        bloc: Get.find<CompaniesCubit>(),
+        builder: (context, compState) {
+          if (!(compState is CompaniesLoadSuccess) ||
+              !compState.selected.canShareMagicLinkByEmail) {
+            return SizedBox.shrink();
+          }
+          return Column(
+            children: [
               SizedBox(height: 54),
               Text(AppLocalizations.of(context)?.sendInvitationByEmail ?? '',
                   style: Theme.of(context)
@@ -241,22 +257,15 @@ class _InvitationPeoplePageState extends State<InvitationPeoplePage> {
                 alignment: Alignment.centerRight,
                 children: [
                   ButtonTextBuilder(Key('button_invite_by_email'),
-                          backgroundColor: Theme.of(context)
-                              .colorScheme
-                              .surface
-                              .withOpacity(0.25),
-                          paddingEdgeInsets: EdgeInsets.only(right: 20),
-                          onButtonClick: () =>
-                              _handleClickOnButtonInviteByEmail())
-                      .setWidth(double.infinity)
-                      .setHeight(50)
-                      .setText(
-                          AppLocalizations.of(context)?.inviteByEmail ?? '')
-                      .setTextStyle(Theme.of(context)
-                          .textTheme
-                          .headline4!
-                          .copyWith(fontSize: 17, fontWeight: FontWeight.w600))
-                      .build(),
+                    backgroundColor: Theme.of(context).colorScheme.surface.withOpacity(0.25),
+                    paddingEdgeInsets: EdgeInsets.only(right: 20),
+                    onButtonClick: () => _handleClickOnButtonInviteByEmail())
+                    .setWidth(double.infinity)
+                    .setHeight(50)
+                    .setText(AppLocalizations.of(context)?.inviteByEmail ?? '')
+                    .setTextStyle(Theme.of(context).textTheme.headline4!
+                      .copyWith(fontSize: 17, fontWeight: FontWeight.w600))
+                    .build(),
                   Container(
                     margin: const EdgeInsets.only(right: 15),
                     child: Image.asset(imageSendEmail, width: 20, height: 20),
@@ -265,9 +274,10 @@ class _InvitationPeoplePageState extends State<InvitationPeoplePage> {
               ),
               SizedBox(height: 16),
             ],
-          ),
-        );
-      });
+          );
+        }
+    );
+  }
 
   Widget _buildLinkField() => GestureDetector(
         onTap: () => _handleClickOnLink(),

--- a/lib/utils/extensions.dart
+++ b/lib/utils/extensions.dart
@@ -76,6 +76,8 @@ extension StringExtension on String {
       return TwakeErrorMessage.UserAlreadyInWorkspace;
     else if(this.contains('Unable to invite this user to your company'))
       return TwakeErrorMessage.UnableInviteUser;
+    else if(this.contains('Pending user already exists'))
+      return TwakeErrorMessage.PendingUserIsExist;
     return TwakeErrorMessage.None;
   }
 }

--- a/lib/utils/extensions.dart
+++ b/lib/utils/extensions.dart
@@ -4,6 +4,7 @@ import 'package:receive_sharing_intent/receive_sharing_intent.dart';
 import 'package:twake/config/image_path.dart';
 import 'package:twake/models/file/local_file.dart';
 import 'package:twake/models/receive_sharing/receive_sharing_file.dart';
+import 'package:twake/utils/twake_error_messages.dart';
 
 extension StringExtension on String {
   bool get isNotReallyEmpty => this.trim().isNotEmpty;
@@ -68,6 +69,14 @@ extension StringExtension on String {
       default:
         return imageFile;
     }
+  }
+
+  TwakeErrorMessage get twakeErrorByStringMessage {
+    if(this.contains('User is already in workspace'))
+      return TwakeErrorMessage.UserAlreadyInWorkspace;
+    else if(this.contains('Unable to invite this user to your company'))
+      return TwakeErrorMessage.UnableInviteUser;
+    return TwakeErrorMessage.None;
   }
 }
 //

--- a/lib/utils/twake_error_messages.dart
+++ b/lib/utils/twake_error_messages.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+enum TwakeErrorMessage {
+  None,
+  EmailIsNotValidFormat,
+  UserAlreadyInWorkspace,
+  UnableInviteUser,
+  SomethingWasWrong,
+}
+
+extension TwakeErrorMessageExtension on TwakeErrorMessage {
+
+  String message(BuildContext context) {
+    switch (this) {
+      case TwakeErrorMessage.EmailIsNotValidFormat:
+        return AppLocalizations.of(context)?.emailIsNotValid ?? '';
+      case TwakeErrorMessage.UserAlreadyInWorkspace:
+        return AppLocalizations.of(context)?.userAlreadyInWorkspace ?? '';
+      case TwakeErrorMessage.UnableInviteUser:
+        return AppLocalizations.of(context)?.unableInviteUser ?? '';
+      case TwakeErrorMessage.SomethingWasWrong:
+        return AppLocalizations.of(context)?.somethingWasWrong ?? '';
+      default:
+        return '';
+    }
+  }
+
+}

--- a/lib/utils/twake_error_messages.dart
+++ b/lib/utils/twake_error_messages.dart
@@ -6,7 +6,7 @@ enum TwakeErrorMessage {
   EmailIsNotValidFormat,
   UserAlreadyInWorkspace,
   UnableInviteUser,
-  SomethingWasWrong,
+  PendingUserIsExist,
 }
 
 extension TwakeErrorMessageExtension on TwakeErrorMessage {
@@ -19,10 +19,10 @@ extension TwakeErrorMessageExtension on TwakeErrorMessage {
         return AppLocalizations.of(context)?.userAlreadyInWorkspace ?? '';
       case TwakeErrorMessage.UnableInviteUser:
         return AppLocalizations.of(context)?.unableInviteUser ?? '';
-      case TwakeErrorMessage.SomethingWasWrong:
-        return AppLocalizations.of(context)?.somethingWasWrong ?? '';
+      case TwakeErrorMessage.PendingUserIsExist:
+        return AppLocalizations.of(context)?.pendingUserExist ?? '';
       default:
-        return '';
+        return AppLocalizations.of(context)?.somethingWasWrong ?? '';
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -89,6 +89,7 @@ dependencies:
   receive_sharing_intent: 1.4.5
   rxdart: ^0.27.3
   flutter_link_previewer: ^2.6.3
+  just_the_tooltip: ^0.0.11+2
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
- Logic changes:
    - Add tooltip to user can see the error message when click on error icon. It can be dismissed and open again by tapping on error icon again.
    - Only navigate into email sent successfully screen if all emails are valid (Before behavior: Navigate into email sent screen when there is at least one valid email and didn't care how many failed email)

- Demo new validation:

https://user-images.githubusercontent.com/29337364/165434500-58898c08-7fc3-485d-9bba-14782c308599.mp4

- Fix header overflow:
<img src="https://user-images.githubusercontent.com/29337364/165434518-cc0d7cd8-a3ae-4f2e-83e3-2eee285dd74c.png" width="360"/>

