### PR TITLE
#1374 fix copy-paste ios

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -93,7 +93,7 @@ void main() async {
           GlobalMaterialLocalizations.delegate,
           GlobalWidgetsLocalizations.delegate,
           GlobalCupertinoLocalizations.delegate,
-          //DefaultCupertinoLocalizations.delegate
+          DefaultCupertinoLocalizations.delegate
         ],
         supportedLocales: [
           const Locale('en'),


### PR DESCRIPTION
#1374 fix copy-paste ios
This might fix this bug, I already fixed similar issue before.
The problem is CupertinoTextSelectionControlsToolbar widgets require CupertinoLocalizations to be provided by a Localizations widget ancestor
